### PR TITLE
Moved CarrierServices to api23hack() since it is only available >= SDK23

### DIFF
--- a/scripts/inc.buildtarget.sh
+++ b/scripts/inc.buildtarget.sh
@@ -26,8 +26,7 @@ vending"
 
 gappscore_optional=""
 
-gappssuper="carrierservices
-dmagent
+gappssuper="dmagent
 earth
 gcs
 googlepay

--- a/scripts/inc.compatibility.sh
+++ b/scripts/inc.compatibility.sh
@@ -454,6 +454,9 @@ pixellauncher"
     gappsstock_optional="$gappsstock_optional
 cameragooglelegacy"
 
+    gappssuper="$gappssuper
+carrierservices"
+
     webviewstocklibs='lib/$WebView_lib_filename
 lib64/$WebView_lib_filename
 ' #on Marshmallow the AOSP WebViewlibs must be removed, since they are embedded in the Google WebView APK; this assumes also any pre-bundled Google WebView with the ROM uses embedded libs; use single quote to not replace variable names


### PR DESCRIPTION
Fixes #.

Changes:
-
-
-
